### PR TITLE
Update install-oci8.sh to install oci8-2.0.10

### DIFF
--- a/scripts/install-oci8.sh
+++ b/scripts/install-oci8.sh
@@ -1,7 +1,7 @@
 if php -m | grep oci8; then
 	echo 'oracle extension already installed!'
 else
-	echo autodetect | pecl install oci8
+	echo autodetect | pecl install oci8-2.0.10
 	echo 'extension=oci8.so' >> /etc/php5/fpm/php.ini
 	echo 'extension=oci8.so' >> /etc/php5/cli/php.ini
 fi


### PR DESCRIPTION
Now installing specific version oci8-2.0.10 for compatibility with PHP 5.x.

Previously it would just do `pecl install oci8` which attempts to install the current version of OCI8, which is 2.1, which only works with PHP7.

See the Description on the [PECL OCI8](https://pecl.php.net/package/oci8) page for details.
